### PR TITLE
[libFuse 3.16.2]Compilation failure on freeBSD #936

### DIFF
--- a/lib/mount_bsd.c
+++ b/lib/mount_bsd.c
@@ -8,7 +8,7 @@
   See the file COPYING.LIB.
 */
 
-#include "config.h"
+#include "fuse_config.h"
 #include "fuse_i.h"
 #include "fuse_misc.h"
 #include "fuse_opt.h"


### PR DESCRIPTION
Despite the creation of the header file fuse_config.h during LibFUSE version 3.16.2's Meson build process, the BSD mount_bsd.c file continues to reference config.h. Consequently, this discrepancy results in compilation failures.

FIX : Point the mount_bsd.c to correct header.